### PR TITLE
Integrate Ticketmaster API and display events as CardView items

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,11 @@ An Android application that gathers and displays upcoming events near the user, 
 
 ## Setup Instructions
 ### API key setup
+To retrieve local event data, the PredictHQ and Ticketmaster APIs are used.
+Please obtain API authentication keys for both APIs and complete the setup steps below.
 1. Create a 'secrets.properties' file in the project root.
 2. Add the following line:
 ```plaintext
 PREDICTHQ_API_KEY=your_api_key_here
+TICKETMASTER_API_KEY=your_api_key_here
 ```  

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -12,6 +12,7 @@ plugins {
 }
 
 val predictHQApiKey = properties["PREDICTHQ_API_KEY"] ?: "MISSING_API_KEY"
+val ticketMasterApiKey = properties["TICKETMASTER_API_KEY"] ?: "MISSING_API_KEY"
 
 android {
     namespace = "com.example.eventFinder"
@@ -25,6 +26,7 @@ android {
         versionName = "1.0"
 
         buildConfigField("String", "PREDICTHQ_API_KEY", "\"${properties["PREDICTHQ_API_KEY"] ?: ""}\"")
+        buildConfigField("String", "TICKETMASTER_API_KEY", "\"${properties["TICKETMASTER_API_KEY"] ?: ""}\"")
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,7 +16,7 @@ val ticketMasterApiKey = properties["TICKETMASTER_API_KEY"] ?: "MISSING_API_KEY"
 
 android {
     namespace = "com.example.eventFinder"
-    compileSdk = 34
+    compileSdk = 35
 
     defaultConfig {
         applicationId = "com.example.eventFinder"
@@ -62,6 +62,7 @@ dependencies {
     implementation(libs.androidx.navigation.ui.ktx)
     implementation(libs.kotlinx.coroutines.android)
     implementation(libs.androidx.lifecycle.runtime.ktx)
+    implementation(libs.androidx.recyclerview)
 
     // Networking
     implementation(libs.retrofit)

--- a/app/src/main/java/com/example/eventFinder/EventsFragment.kt
+++ b/app/src/main/java/com/example/eventFinder/EventsFragment.kt
@@ -33,7 +33,8 @@ import com.google.android.gms.location.Priority
 
 class EventsFragment : Fragment() {
     private val viewModel: EventsViewModel by viewModels()
-    private val authToken = "Bearer " + BuildConfig.PREDICTHQ_API_KEY
+    private val authTokenPredictHq = "Bearer " + BuildConfig.PREDICTHQ_API_KEY
+    private val authTokenTicketmaster = BuildConfig.TICKETMASTER_API_KEY
 
     private lateinit var progressBar: ProgressBar
     private lateinit var locationOffView: LinearLayout
@@ -79,7 +80,7 @@ class EventsFragment : Fragment() {
 
                 val radius = 5.0 // TODO: Retrieve radius from user input instead of hardcoded value
                 viewModel.setRadius(radius)
-                viewModel.fetchEvents(authToken)
+                viewModel.fetchEvents(authTokenPredictHq)
 
                 showLayout(locationAccessed = true)
             }

--- a/app/src/main/java/com/example/eventFinder/EventsFragment.kt
+++ b/app/src/main/java/com/example/eventFinder/EventsFragment.kt
@@ -21,6 +21,7 @@ import androidx.annotation.RequiresPermission
 import androidx.core.content.ContextCompat
 import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
+import androidx.recyclerview.widget.ConcatAdapter
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.example.eventFinder.viewmodels.EventsViewModel
@@ -46,6 +47,7 @@ class EventsFragment : Fragment() {
     private lateinit var longTextView: TextView
 
     private lateinit var predictHqEventAdapter: PredictHqEventAdapter
+    private lateinit var ticketmasterEventAdapter: TicketmasterEventAdapter
 
     private lateinit var client: FusedLocationProviderClient
 
@@ -68,9 +70,11 @@ class EventsFragment : Fragment() {
         longTextView = view.findViewById(R.id.long_text_view)
 
         predictHqEventAdapter = PredictHqEventAdapter(emptyList())
+        ticketmasterEventAdapter = TicketmasterEventAdapter(emptyList())
 
         recyclerView.layoutManager = LinearLayoutManager(requireContext())
-        recyclerView.adapter = predictHqEventAdapter
+        val concatAdapter = ConcatAdapter(predictHqEventAdapter, ticketmasterEventAdapter)
+        recyclerView.adapter = concatAdapter
 
         client = LocationServices.getFusedLocationProviderClient(requireContext())
 
@@ -89,6 +93,10 @@ class EventsFragment : Fragment() {
 
         viewModel.predictHqEventsData.observe(viewLifecycleOwner) { eventsResponse ->
             eventsResponse?.let { predictHqEventAdapter.updateEvents(eventsResponse.results) }
+        }
+
+        viewModel.ticketMasterEventsData.observe(viewLifecycleOwner) { eventsResponse ->
+            eventsResponse?.let { ticketmasterEventAdapter.updateEvents(eventsResponse.embedded.ticketMasterEvents) }
         }
 
         val fineLocationAccess = ContextCompat.checkSelfPermission(requireContext(), Manifest.permission.ACCESS_FINE_LOCATION)

--- a/app/src/main/java/com/example/eventFinder/EventsFragment.kt
+++ b/app/src/main/java/com/example/eventFinder/EventsFragment.kt
@@ -33,8 +33,8 @@ import com.google.android.gms.location.Priority
 
 class EventsFragment : Fragment() {
     private val viewModel: EventsViewModel by viewModels()
-    private val authTokenPredictHq = "Bearer " + BuildConfig.PREDICTHQ_API_KEY
-    private val authTokenTicketmaster = BuildConfig.TICKETMASTER_API_KEY
+    private val predictHqAuthToken = "Bearer " + BuildConfig.PREDICTHQ_API_KEY
+    private val ticketMasterAuthToken = BuildConfig.TICKETMASTER_API_KEY
 
     private lateinit var progressBar: ProgressBar
     private lateinit var locationOffView: LinearLayout
@@ -80,7 +80,7 @@ class EventsFragment : Fragment() {
 
                 val radius = 5.0 // TODO: Retrieve radius from user input instead of hardcoded value
                 viewModel.setRadius(radius)
-                viewModel.fetchEvents(authTokenPredictHq)
+                viewModel.fetchEvents(predictHqAuthToken)
 
                 showLayout(locationAccessed = true)
             }

--- a/app/src/main/java/com/example/eventFinder/EventsFragment.kt
+++ b/app/src/main/java/com/example/eventFinder/EventsFragment.kt
@@ -45,7 +45,7 @@ class EventsFragment : Fragment() {
     private lateinit var latTextView: TextView
     private lateinit var longTextView: TextView
 
-    private lateinit var eventAdapter: EventAdapter
+    private lateinit var predictHqEventAdapter: PredictHqEventAdapter
 
     private lateinit var client: FusedLocationProviderClient
 
@@ -67,9 +67,10 @@ class EventsFragment : Fragment() {
         latTextView = view.findViewById(R.id.lat_text_view)
         longTextView = view.findViewById(R.id.long_text_view)
 
-        eventAdapter = EventAdapter(emptyList())
+        predictHqEventAdapter = PredictHqEventAdapter(emptyList())
+
         recyclerView.layoutManager = LinearLayoutManager(requireContext())
-        recyclerView.adapter = eventAdapter
+        recyclerView.adapter = predictHqEventAdapter
 
         client = LocationServices.getFusedLocationProviderClient(requireContext())
 
@@ -78,16 +79,16 @@ class EventsFragment : Fragment() {
                 latTextView.text = location.latitude.toString()
                 longTextView.text = location.longitude.toString()
 
-                val radius = 5.0 // TODO: Retrieve radius from user input instead of hardcoded value
+                val radius = 5 // TODO: Retrieve radius from user input instead of hardcoded value
                 viewModel.setRadius(radius)
-                viewModel.fetchEvents(predictHqAuthToken)
+                viewModel.fetchEvents(predictHqAuthToken, ticketMasterAuthToken)
 
                 showLayout(locationAccessed = true)
             }
         }
 
-        viewModel.eventsData.observe(viewLifecycleOwner) { eventsResponse ->
-            eventsResponse?.let { eventAdapter.updateEvents(eventsResponse.results) }
+        viewModel.predictHqEventsData.observe(viewLifecycleOwner) { eventsResponse ->
+            eventsResponse?.let { predictHqEventAdapter.updateEvents(eventsResponse.results) }
         }
 
         val fineLocationAccess = ContextCompat.checkSelfPermission(requireContext(), Manifest.permission.ACCESS_FINE_LOCATION)

--- a/app/src/main/java/com/example/eventFinder/MainActivity.kt
+++ b/app/src/main/java/com/example/eventFinder/MainActivity.kt
@@ -18,35 +18,5 @@ class MainActivity : AppCompatActivity() {
         val navController: NavController = navHostFragment.navController
         val bottomNavigationView = findViewById<BottomNavigationView>(R.id.bottom_navigation_view)
         NavigationUI.setupWithNavController(bottomNavigationView, navController)
-
-
-//        val navController = findNavController(R.id.nav_host_fragment)
-
-        // Setup navbar (all bottom 3 options seem to work)
-        // Option1
-//        bottomNavigationView.setupWithNavController(navController)
-
-        // Option2
-//        NavigationUI.setupWithNavController(bottomNavigationView, navController)
-
-        //Option3
-//        bottomNavigationView.setOnItemSelectedListener { item ->
-//            when(item.itemId) {
-//                R.id.nav_home -> {
-//                    navController.navigate(R.id.nav_home)
-//                    true
-//                }
-//                R.id.nav_events -> {
-//                    navController.navigate(R.id.nav_events)
-//                    true
-//                }
-//                R.id.nav_profile -> {
-//                    navController.navigate(R.id.nav_profile)
-//                    true
-//                }
-//                else -> false
-//            }
-//        }
-
     }
 }

--- a/app/src/main/java/com/example/eventFinder/PredictHqEventAdapter.kt
+++ b/app/src/main/java/com/example/eventFinder/PredictHqEventAdapter.kt
@@ -5,10 +5,10 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
 import androidx.recyclerview.widget.RecyclerView
-import com.example.eventFinder.model.EventItem
+import com.example.eventFinder.model.PredictHqEventItem
 
-class EventAdapter(private var eventDataSet: List<EventItem>):
-    RecyclerView.Adapter<EventAdapter.ViewHolder>() {
+class PredictHqEventAdapter(private var eventDataSet: List<PredictHqEventItem>):
+    RecyclerView.Adapter<PredictHqEventAdapter.ViewHolder>() {
 
     class ViewHolder(view: View) : RecyclerView.ViewHolder(view) {
         val eventTitle: TextView = view.findViewById(R.id.eventTitle)
@@ -34,7 +34,7 @@ class EventAdapter(private var eventDataSet: List<EventItem>):
 
     override fun getItemCount() = eventDataSet.size
 
-    fun updateEvents(newEvents: List<EventItem>) {
+    fun updateEvents(newEvents: List<PredictHqEventItem>) {
         eventDataSet = newEvents
         notifyDataSetChanged()
     }

--- a/app/src/main/java/com/example/eventFinder/TicketmasterEventAdapter.kt
+++ b/app/src/main/java/com/example/eventFinder/TicketmasterEventAdapter.kt
@@ -1,0 +1,41 @@
+package com.example.eventFinder
+
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.TextView
+import androidx.recyclerview.widget.RecyclerView
+import com.example.eventFinder.model.TicketmasterEventItem
+
+class TicketmasterEventAdapter(private var eventDataSet: List<TicketmasterEventItem>): RecyclerView.Adapter<TicketmasterEventAdapter.ViewHolder>() {
+
+    class ViewHolder(view: View): RecyclerView.ViewHolder(view) {
+        val eventTitle: TextView = view.findViewById(R.id.eventTitle)
+        val eventLocation: TextView = view.findViewById(R.id.eventLocation)
+        val eventCategory: TextView = view.findViewById(R.id.eventCategory)
+        val eventStart: TextView = view.findViewById(R.id.eventStart)
+        val eventEnd: TextView = view.findViewById(R.id.eventEnd)
+    }
+
+    override fun onCreateViewHolder(viewGroup: ViewGroup, viewType: Int): ViewHolder {
+        val view = LayoutInflater.from(viewGroup.context).inflate(R.layout.card_event_item, viewGroup, false)
+        return ViewHolder(view)
+    }
+
+    override fun onBindViewHolder(viewHolder: ViewHolder, position: Int) {
+        val event = eventDataSet[position]
+        val location = event.embedded?.venues?.first() ?: event.place
+        viewHolder.eventTitle.text = event.name
+        viewHolder.eventLocation.text = location?.city?.name
+        viewHolder.eventCategory.text = event.classifications?.first()?.segment?.name
+        viewHolder.eventStart.text = event.dates.start.dateTime
+        viewHolder.eventEnd.text = event.dates.end?.dateTime
+    }
+
+    override fun getItemCount() = eventDataSet.size
+
+    fun updateEvents(newEvents: List<TicketmasterEventItem>) {
+        eventDataSet = newEvents
+        notifyDataSetChanged()
+    }
+}

--- a/app/src/main/java/com/example/eventFinder/model/PredictHqEventResponse.kt
+++ b/app/src/main/java/com/example/eventFinder/model/PredictHqEventResponse.kt
@@ -2,15 +2,15 @@ package com.example.eventFinder.model
 
 import com.google.gson.annotations.SerializedName
 
-data class EventResponse(
+data class PredictHqEventResponse(
     @SerializedName("count") val count: Int,
     @SerializedName("overflow") val overflow: String?,
     @SerializedName("previous") val previous: String?,
     @SerializedName("next") val next: String?,
-    @SerializedName("results") val results: List<EventItem>
+    @SerializedName("results") val results: List<PredictHqEventItem>
 )
 
-data class EventItem(
+data class PredictHqEventItem(
     @SerializedName("id") val id: String,
     @SerializedName("description") val description: String,
     @SerializedName("category") val category: String,

--- a/app/src/main/java/com/example/eventFinder/model/TicketmasterEventResponse.kt
+++ b/app/src/main/java/com/example/eventFinder/model/TicketmasterEventResponse.kt
@@ -1,0 +1,101 @@
+package com.example.eventFinder.model
+
+import com.google.gson.annotations.SerializedName
+
+// Hierarchy 1
+data class TicketmasterEventResponse(
+    @SerializedName("_embedded") val embedded: EmbeddedEvents,
+)
+
+// Hierarchy 2
+data class EmbeddedEvents(
+    @SerializedName("events") val ticketMasterEvents: List<TicketmasterEventItem>,
+)
+
+// Hierarchy 3
+data class TicketmasterEventItem(
+    val name: String,
+    val id: String,
+    val url: String,
+    val images: List<Image>?,
+    val dates: Dates,
+    val classifications: List<Classification>?,
+    val description: String?,
+    @SerializedName("_embedded") val embedded: Embedded?,
+    val place: PlaceOrVenue?,
+)
+
+// Hierarchy 4
+data class Image(
+    val url: String,
+    val width: Int,
+    val height: Int,
+    val attribution: String,
+)
+
+data class Dates(
+    val start: DateDetails,
+    val end: DateDetails?,
+    val timezone: String?,
+)
+
+data class Classification(
+    val primary: Boolean,
+    val segment: ClassificationItem, // primary genre for an entity (Music, Sports, Arts, etc.)
+    val genre: ClassificationItem, // secondary genre (Rock, Classical, Animation, etc)
+    val subgenre: ClassificationItem, // tertiary genre (Alternative Rock, Ambient Pop, etc)
+)
+
+data class Embedded(
+    val venues: List<PlaceOrVenue>,
+)
+
+data class PlaceOrVenue(
+    val address: Address?,
+    val city: City?,
+    val state: State?,
+    val country: Country?,
+    val postalCode: String?,
+    val location: Location?,
+    val name: String,
+    val description: String?,
+    val type: String?,
+)
+
+// Hierarchy 5
+data class DateDetails(
+    val localDate: String?,
+    val localTime: String?,
+    val dateTime: String?,
+    val noSpecificTime: Boolean?,
+)
+
+data class ClassificationItem(
+    val id: String,
+    val name: String,
+)
+
+data class Address(
+    val line1: String,
+    val line2: String?,
+    val line3: String?,
+)
+
+data class City(
+    val name: String,
+)
+
+data class State(
+    val stateCode: String,
+    val name: String,
+)
+
+data class Country(
+    val countryCode: String,
+    val name: String,
+)
+
+data class Location(
+    val longitude: String,
+    val latitude: String,
+)

--- a/app/src/main/java/com/example/eventFinder/network/EventRepository.kt
+++ b/app/src/main/java/com/example/eventFinder/network/EventRepository.kt
@@ -1,18 +1,16 @@
 package com.example.eventFinder.network
 
-import com.example.eventFinder.model.EventResponse
+import com.example.eventFinder.model.PredictHqEventResponse
 import retrofit2.Call
 import retrofit2.Callback
 import retrofit2.Response
 
 class EventRepository {
-    fun getEvents(radiusKm: Double, lat: Double, long: Double, authToken: String,
-                   callback: (EventResponse?) -> Unit) {
-        val eventService = RetrofitInstance.eventService
-
-        eventService.getEvents(authToken, composeWithinQuery(radiusKm, lat, long))
-            .enqueue(object : Callback<EventResponse> {
-                override fun onResponse(call: Call<EventResponse>, response: Response<EventResponse>) {
+    fun getPredictHqEvents(radiusKm: Double, lat: Double, long: Double, authToken: String,
+                           callback: (PredictHqEventResponse?) -> Unit) {
+        RetrofitInstance.predictHqEventService.getPredictHqEvents(authToken, composeWithinQuery(radiusKm, lat, long))
+            .enqueue(object : Callback<PredictHqEventResponse> {
+                override fun onResponse(call: Call<PredictHqEventResponse>, response: Response<PredictHqEventResponse>) {
                     if (response.isSuccessful) {
                         response.body()?.let {
                             callback(it)
@@ -22,7 +20,7 @@ class EventRepository {
                     }
                 }
 
-                override fun onFailure(call: Call<EventResponse>, t: Throwable) {
+                override fun onFailure(call: Call<PredictHqEventResponse>, t: Throwable) {
                     callback(null)
                 }
             })

--- a/app/src/main/java/com/example/eventFinder/network/EventRepository.kt
+++ b/app/src/main/java/com/example/eventFinder/network/EventRepository.kt
@@ -1,12 +1,13 @@
 package com.example.eventFinder.network
 
 import com.example.eventFinder.model.PredictHqEventResponse
+import com.example.eventFinder.model.TicketmasterEventResponse
 import retrofit2.Call
 import retrofit2.Callback
 import retrofit2.Response
 
 class EventRepository {
-    fun getPredictHqEvents(radiusKm: Double, lat: Double, long: Double, authToken: String,
+    fun getPredictHqEvents(radiusKm: Int, lat: Double, long: Double, authToken: String,
                            callback: (PredictHqEventResponse?) -> Unit) {
         RetrofitInstance.predictHqEventService.getPredictHqEvents(authToken, composeWithinQuery(radiusKm, lat, long))
             .enqueue(object : Callback<PredictHqEventResponse> {
@@ -26,7 +27,32 @@ class EventRepository {
             })
         }
 
-    private fun composeWithinQuery(radiusKm: Double, lat: Double, long: Double): String {
+    fun getTicketmasterEvents(radiusKm: Int, lat: Double, long: Double, authToken: String,
+                              callback: (TicketmasterEventResponse?) -> Unit) {
+        // TODO: Radius unit "km" currently hardcoded. Give option to use "miles"
+        RetrofitInstance.ticketMasterEventService.getTicketmasterEvents(authToken, composeLatLongQuery(lat, long), radiusKm, "km")
+            .enqueue(object : Callback<TicketmasterEventResponse> {
+            override fun onResponse(call: Call<TicketmasterEventResponse>, response: Response<TicketmasterEventResponse>) {
+                if (response.isSuccessful) {
+                    response.body()?.let {
+                        callback(it)
+                    }
+                } else {
+                    callback(null)
+                }
+            }
+
+            override fun onFailure(call: Call<TicketmasterEventResponse>, t: Throwable) {
+                callback(null)
+            }
+        })
+    }
+
+    private fun composeWithinQuery(radiusKm: Int, lat: Double, long: Double): String {
         return radiusKm.toString() + "km@" + lat.toString() + "," + long.toString()
+    }
+
+    private fun composeLatLongQuery(lat: Double, long: Double): String {
+        return "$lat,$long"
     }
 }

--- a/app/src/main/java/com/example/eventFinder/network/EventService.kt
+++ b/app/src/main/java/com/example/eventFinder/network/EventService.kt
@@ -1,6 +1,6 @@
 package com.example.eventFinder.network
 
-import com.example.eventFinder.model.EventResponse
+import com.example.eventFinder.model.PredictHqEventResponse
 import retrofit2.Call
 import retrofit2.http.GET
 import retrofit2.http.Header
@@ -8,8 +8,8 @@ import retrofit2.http.Query
 
 interface EventService {
     @GET("events/")
-    fun getEvents(
+    fun getPredictHqEvents(
         @Header("Authorization") authToken: String,
         @Query("within") within: String
-    ): Call<EventResponse>
+    ): Call<PredictHqEventResponse>
 }

--- a/app/src/main/java/com/example/eventFinder/network/EventService.kt
+++ b/app/src/main/java/com/example/eventFinder/network/EventService.kt
@@ -1,6 +1,7 @@
 package com.example.eventFinder.network
 
 import com.example.eventFinder.model.PredictHqEventResponse
+import com.example.eventFinder.model.TicketmasterEventResponse
 import retrofit2.Call
 import retrofit2.http.GET
 import retrofit2.http.Header
@@ -12,4 +13,12 @@ interface EventService {
         @Header("Authorization") authToken: String,
         @Query("within") within: String
     ): Call<PredictHqEventResponse>
+
+    @GET("events.json")
+    fun getTicketmasterEvents(
+        @Query("apikey") authToken: String,
+        @Query("latlong") latLong: String,
+        @Query("radius") radius: Int,
+        @Query("unit") radiusUnit: String
+    ): Call<TicketmasterEventResponse>
 }

--- a/app/src/main/java/com/example/eventFinder/network/RetrofitInstance.kt
+++ b/app/src/main/java/com/example/eventFinder/network/RetrofitInstance.kt
@@ -7,6 +7,7 @@ import retrofit2.converter.gson.GsonConverterFactory
 
 object RetrofitInstance {
     private const val PREDICT_HQ_BASE_URL = "https://api.predicthq.com/v1/"
+    private const val TICKETMASTER_BASE_URL = "https://app.ticketmaster.com/discovery/v2/"
 
     private val loggingInterceptor = HttpLoggingInterceptor().apply {
         level = HttpLoggingInterceptor.Level.BODY
@@ -24,7 +25,19 @@ object RetrofitInstance {
             .build()
     }
 
+    private val ticketMasterRetrofit: Retrofit by lazy {
+        Retrofit.Builder()
+            .baseUrl(TICKETMASTER_BASE_URL)
+            .addConverterFactory(GsonConverterFactory.create())
+            .client(client)
+            .build()
+    }
+
     val predictHqEventService: EventService by lazy {
         predictHqRetrofit.create(EventService::class.java)
+    }
+
+    val ticketMasterEventService: EventService by lazy {
+        ticketMasterRetrofit.create(EventService::class.java)
     }
 }

--- a/app/src/main/java/com/example/eventFinder/network/RetrofitInstance.kt
+++ b/app/src/main/java/com/example/eventFinder/network/RetrofitInstance.kt
@@ -6,7 +6,7 @@ import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 
 object RetrofitInstance {
-    private const val BASE_URL = "https://api.predicthq.com/v1/"
+    private const val PREDICT_HQ_BASE_URL = "https://api.predicthq.com/v1/"
 
     private val loggingInterceptor = HttpLoggingInterceptor().apply {
         level = HttpLoggingInterceptor.Level.BODY
@@ -16,15 +16,15 @@ object RetrofitInstance {
         .addInterceptor(loggingInterceptor)
         .build()
 
-    private val retrofit: Retrofit by lazy {
+    private val predictHqRetrofit: Retrofit by lazy {
         Retrofit.Builder()
-            .baseUrl(BASE_URL)
+            .baseUrl(PREDICT_HQ_BASE_URL)
             .addConverterFactory(GsonConverterFactory.create())
             .client(client)
             .build()
     }
 
-    val eventService: EventService by lazy {
-        retrofit.create(EventService::class.java)
+    val predictHqEventService: EventService by lazy {
+        predictHqRetrofit.create(EventService::class.java)
     }
 }

--- a/app/src/main/java/com/example/eventFinder/viewmodels/EventsViewModel.kt
+++ b/app/src/main/java/com/example/eventFinder/viewmodels/EventsViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import com.example.eventFinder.network.EventRepository
 import com.example.eventFinder.model.PredictHqEventResponse
+import com.example.eventFinder.model.TicketmasterEventResponse
 
 class EventsViewModel : ViewModel() {
     private val repository = EventRepository()
@@ -20,17 +21,23 @@ class EventsViewModel : ViewModel() {
     private val _predictHqEventsData = MutableLiveData<PredictHqEventResponse>()
     val predictHqEventsData: LiveData<PredictHqEventResponse> get() = _predictHqEventsData
 
-    private val _radiusInput = MutableLiveData<Double>()
-    val radiusInput: LiveData<Double> get() = _radiusInput
+    private val _ticketMasterEventsData = MutableLiveData<TicketmasterEventResponse>()
+    val ticketMasterEventsData: LiveData<TicketmasterEventResponse> get() = _ticketMasterEventsData
 
-    fun setRadius(radius: Double) {
+    private val _radiusInput = MutableLiveData<Int>()
+    val radiusInput: LiveData<Int> get() = _radiusInput
+
+    fun setRadius(radius: Int) {
         _radiusInput.value = radius
     }
 
-    fun fetchEvents(predictHqAuthToken: String) {
+    fun fetchEvents(predictHqAuthToken: String, ticketmasterAuthToken: String) {
         if (radiusInput.value != null && location.value != null) {
             repository.getPredictHqEvents(radiusInput.value!!, location.value!!.latitude, location.value!!.longitude, predictHqAuthToken) {
                 _predictHqEventsData.value = it
+            }
+            repository.getTicketmasterEvents(radiusInput.value!!, location.value!!.latitude, location.value!!.longitude, ticketmasterAuthToken) {
+                _ticketMasterEventsData.value = it
             }
         }
     }

--- a/app/src/main/java/com/example/eventFinder/viewmodels/EventsViewModel.kt
+++ b/app/src/main/java/com/example/eventFinder/viewmodels/EventsViewModel.kt
@@ -5,7 +5,7 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import com.example.eventFinder.network.EventRepository
-import com.example.eventFinder.model.EventResponse
+import com.example.eventFinder.model.PredictHqEventResponse
 
 class EventsViewModel : ViewModel() {
     private val repository = EventRepository()
@@ -17,8 +17,8 @@ class EventsViewModel : ViewModel() {
         _location.value = location
     }
 
-    private val _eventsData = MutableLiveData<EventResponse>()
-    val eventsData: LiveData<EventResponse> get() = _eventsData
+    private val _predictHqEventsData = MutableLiveData<PredictHqEventResponse>()
+    val predictHqEventsData: LiveData<PredictHqEventResponse> get() = _predictHqEventsData
 
     private val _radiusInput = MutableLiveData<Double>()
     val radiusInput: LiveData<Double> get() = _radiusInput
@@ -27,10 +27,10 @@ class EventsViewModel : ViewModel() {
         _radiusInput.value = radius
     }
 
-    fun fetchEvents(authToken: String) {
+    fun fetchEvents(predictHqAuthToken: String) {
         if (radiusInput.value != null && location.value != null) {
-            repository.getEvents(radiusInput.value!!, location.value!!.latitude, location.value!!.longitude, authToken) {
-                _eventsData.value = it
+            repository.getPredictHqEvents(radiusInput.value!!, location.value!!.latitude, location.value!!.longitude, predictHqAuthToken) {
+                _predictHqEventsData.value = it
             }
         }
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,12 +15,14 @@ activity = "1.8.0"
 navigationFragmentKtx = "2.8.0"
 navigationUiKtx = "2.8.0"
 playServicesLocation = "21.3.0"
+recyclerview = "1.4.0"
 retrofit = "2.9.0"
 
 [libraries]
 androidx-constraintlayout-v221 = { module = "androidx.constraintlayout:constraintlayout", version.ref = "androidxConstraintlayout" }
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
 androidx-lifecycle-runtime-ktx = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version.ref = "lifecycleRuntimeKtx" }
+androidx-recyclerview = { module = "androidx.recyclerview:recyclerview", version.ref = "recyclerview" }
 converter-gson = { module = "com.squareup.retrofit2:converter-gson", version.ref = "retrofit" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }


### PR DESCRIPTION
### In this PR
1. Rename event identifiers to predictHQEvents to distinguish from other API events
2. Integrate Ticketmaster API and display events as CardView items
3. Delete obsolete navigation bar initialization